### PR TITLE
Add admin UI support for assignment file editing

### DIFF
--- a/src/main/java/minskim2/JHP_World/domain/assignment/dto/AssignmentReq.java
+++ b/src/main/java/minskim2/JHP_World/domain/assignment/dto/AssignmentReq.java
@@ -24,6 +24,12 @@ public class AssignmentReq {
     ) {
     }
 
+    public record UpdateFile(
+            Long assignmentId,
+            MultipartFile file
+    ) {
+    }
+
     public record Delete(
             Long id
     ) {

--- a/src/main/java/minskim2/JHP_World/domain/assignment/entity/Assignment.java
+++ b/src/main/java/minskim2/JHP_World/domain/assignment/entity/Assignment.java
@@ -48,4 +48,8 @@ public class Assignment extends BaseEntity {
             this.body = assignmentDto.body();
         }
     }
+
+    public void updateFile(File file) {
+        this.file = file;
+    }
 }

--- a/src/main/java/minskim2/JHP_World/domain/assignment/service/AssignmentService.java
+++ b/src/main/java/minskim2/JHP_World/domain/assignment/service/AssignmentService.java
@@ -92,6 +92,22 @@ public class AssignmentService {
         return assignment.getId();
     }
 
+    @Transactional
+    public String updateAssignmentFile(AssignmentReq.UpdateFile req) {
+        Assignment assignment = assignmentRepository.findById(req.assignmentId())
+                .orElseThrow(() -> CustomException.of(ASSIGNMENT_NOT_FOUND));
+
+        try {
+            String filePath = gitHubFileUtil.upload(req.file(), "application/pdf");
+            FileDto fileDto = fileService.createFile(req.file().getOriginalFilename(), filePath, "pdf");
+            assignment.updateFile(File.ById(fileDto.getId()));
+            return AssignmentDto.convertPdfUrl(fileDto.getUrl());
+        } catch (Exception e) {
+            log.error("파일 업로드 중 오류 발생: {}", e.getMessage());
+            throw CustomException.of(ASSIGNMENT_FILE_UPLOAD_FAILED);
+        }
+    }
+
     /**
      * Assignment 삭제 메소드
      * */

--- a/src/main/java/minskim2/JHP_World/router/api/AdminRestController.java
+++ b/src/main/java/minskim2/JHP_World/router/api/AdminRestController.java
@@ -53,6 +53,11 @@ public class AdminRestController {
         return assignmentService.updateAssignment(req);
     }
 
+    @PatchMapping("/assignment/file")
+    public String updateAssignmentFile(@ModelAttribute AssignmentReq.UpdateFile req) {
+        return assignmentService.updateAssignmentFile(req);
+    }
+
     /**
      * 과제 삭제
      * */

--- a/src/main/resources/templates/pages/admin/assignment.html
+++ b/src/main/resources/templates/pages/admin/assignment.html
@@ -287,6 +287,7 @@
 
             <h3>과제 파일</h3>
             <iframe id="popup-assignment-file" src="http://docs.google.com/gview?url=https://github.com/user-attachments/files/18808858/Rmd_beamer.pdf&embedded=true" width="100%" height="500px"></iframe>
+            <input type="file" id="popup-assignment-file-input" name="file">
             <div class="popup-buttons">
                 <button class="btn-save" id="saveAssignmentButton">저장</button>
                 <button class="btn-delete" id="deleteAssignmentButton">삭제</button>
@@ -313,6 +314,7 @@
         const popupOverlay = document.getElementById("editPopup");
         const saveAssignmentButton = document.getElementById("saveAssignmentButton");
         const deleteAssignmentButton = document.getElementById("deleteAssignmentButton");
+        const fileInput = document.getElementById("popup-assignment-file-input");
 
         const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute("content");
         const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute("content");
@@ -330,6 +332,7 @@
                         document.getElementById('popup-assignment-title').value = data.title;
                         document.getElementById('popup-assignment-body').value = data.body;
                         document.getElementById('popup-assignment-file').src = data.fileUrl;
+                        fileInput.value = '';
 
                         popupOverlay.style.display = "block";
                     });
@@ -366,13 +369,38 @@
                     body: JSON.stringify(assignmentData)
                 });
 
-                if (response.ok) {
-                    alert('과제가 저장되었습니다.');
-                    location.reload();
-                } else {
+                if (!response.ok) {
                     const errorData = await response.json();
                     alert('저장 실패: ' + errorData.message);
+                    return;
                 }
+
+                if (fileInput.files.length) {
+                    const formData = new FormData();
+                    formData.append('assignmentId', assignmentData.id);
+                    formData.append('file', fileInput.files[0]);
+
+                    const fileResponse = await fetch('/api/admin/assignment/file', {
+                        method: 'PATCH',
+                        headers: {
+                            [csrfHeader]: csrfToken
+                        },
+                        body: formData
+                    });
+
+                    if (!fileResponse.ok) {
+                        const errorData = await fileResponse.json();
+                        alert('파일 수정 실패: ' + errorData.message);
+                        return;
+                    }
+
+                    const newUrl = await fileResponse.text();
+                    document.getElementById('popup-assignment-file').src = newUrl;
+                    fileInput.value = '';
+                }
+
+                alert('과제가 저장되었습니다.');
+                location.reload();
             } catch (error) {
                 console.error('API 요청 중 오류 발생:', error);
                 alert('알 수 없는 오류가 발생했습니다.');
@@ -405,6 +433,7 @@
                 }
             }
         });
+
     });
 </script>
 


### PR DESCRIPTION
## Summary
- allow file updates via API
- add UpdateFile record and service method
- expose new endpoint `/api/admin/assignment/file`
- let admin upload a new assignment file in the popup
- update save button to patch assignment and file together

## Testing
- `gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6843ea35256083249dc7a96b74119a9a