### PR TITLE
Display latest testcase results

### DIFF
--- a/src/main/java/minskim2/JHP_World/domain/grade/repository/GradeRepository.java
+++ b/src/main/java/minskim2/JHP_World/domain/grade/repository/GradeRepository.java
@@ -2,15 +2,22 @@ package minskim2.JHP_World.domain.grade.repository;
 
 import minskim2.JHP_World.domain.grade.entity.Grade;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.nio.channels.FileChannel;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 @Repository
 public interface GradeRepository extends JpaRepository<Grade, Long> {
 
     Page<Grade> findAllByAssignmentId(Long assignmentId, Pageable of);
+
+    /**
+     * 테스트케이스별 최근 채점 결과 조회 (결과가 존재하는 항목만)
+     */
+    @Query("select g from Grade g where g.testCase.id = :testCaseId and g.result is not null order by g.createdDate desc")
+    List<Grade> findRecentGrades(@Param("testCaseId") Long testCaseId, Pageable pageable);
 }

--- a/src/main/java/minskim2/JHP_World/domain/grade/service/GradeService.java
+++ b/src/main/java/minskim2/JHP_World/domain/grade/service/GradeService.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 import static minskim2.JHP_World.global.enums.SizeEnum.GRADE_LIST;
 
@@ -126,5 +127,16 @@ public class GradeService {
     public Page<GradeResponse> getGradeListByAssignmentId(Long assignmentId, int page) {
         return gradeRepository.findAllByAssignmentId(assignmentId, PageRequest.of(page, GRADE_LIST.getSize(), Sort.Direction.DESC, "createdDate"))
                 .map(GradeResponse::from);
+    }
+
+    /**
+     * 테스트케이스별 최근 테스트 결과 조회
+     */
+    public List<GradeResponse> getRecentGradesByTestCaseId(Long testCaseId) {
+        return gradeRepository
+                .findRecentGrades(testCaseId, PageRequest.of(0, 5))
+                .stream()
+                .map(GradeResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/minskim2/JHP_World/router/view/TestCaseController.java
+++ b/src/main/java/minskim2/JHP_World/router/view/TestCaseController.java
@@ -3,6 +3,9 @@ package minskim2.JHP_World.router.view;
 import lombok.RequiredArgsConstructor;
 import minskim2.JHP_World.domain.test_case.dto.TestCaseRes;
 import minskim2.JHP_World.domain.test_case.service.TestCaseService;
+import minskim2.JHP_World.domain.grade.dto.GradeResponse;
+import minskim2.JHP_World.domain.grade.service.GradeService;
+import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,13 +18,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class TestCaseController {
 
     private final TestCaseService testCaseService;
+    private final GradeService gradeService;
 
 
     @GetMapping("/{testCaseId}")
     public String getTestCaseById(@PathVariable Long testCaseId, Model model) {
 
         TestCaseRes.Get testcase = testCaseService.findById(testCaseId);
+        List<GradeResponse> recentGrades = gradeService.getRecentGradesByTestCaseId(testCaseId);
         model.addAttribute("testcase", testcase);
+        model.addAttribute("recentGrades", recentGrades);
 
         return "pages/testcase";
     }

--- a/src/main/resources/templates/pages/testcase.html
+++ b/src/main/resources/templates/pages/testcase.html
@@ -17,12 +17,41 @@
         }
 
         .container {
-            max-width: 800px;
+            max-width: 1000px;
             margin: 30px auto;
             padding: 20px;
             background-color: #fff;
             border-radius: 10px;
             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            display: flex;
+        }
+
+        .testcase-content {
+            flex: 1;
+            margin-right: 30px;
+        }
+
+        .result-panel {
+            width: 250px;
+        }
+
+        .result-panel h3 {
+            margin-top: 0;
+            font-size: 1.1rem;
+            margin-bottom: 10px;
+        }
+
+        .result-panel ul {
+            list-style: none;
+            padding: 0;
+        }
+
+        .result-panel li {
+            background-color: #f7f7f7;
+            border-radius: 5px;
+            padding: 8px 10px;
+            margin-bottom: 8px;
+            font-size: 0.9rem;
         }
 
         h1 {
@@ -65,13 +94,23 @@
 </div>
 
 <div class="container">
-    <h1 th:text="${testcase.assignmentTitle}"></h1>
-    <p th:text="${testcase.member}" style="text-align: right"></p>
-    <p th:text="${testcase.description}"></p>
-    <h4>input</h4>
-    <p th:text="${testcase.input}"></p>
-    <h4>output</h4>
-    <p th:text="${testcase.output}"></p>
+    <div class="testcase-content">
+        <h1 th:text="${testcase.assignmentTitle}"></h1>
+        <p th:text="${testcase.member}" style="text-align: right"></p>
+        <p th:text="${testcase.description}"></p>
+        <h4>input</h4>
+        <p th:text="${testcase.input}"></p>
+        <h4>output</h4>
+        <p th:text="${testcase.output}"></p>
+    </div>
+    <div class="result-panel">
+        <h3>최근 실행 결과</h3>
+        <ul>
+            <li th:each="grade : ${recentGrades}"
+                th:text="${grade.result == null ? '채점 중' : (grade.success ? '성공' : grade.result)}"></li>
+            <li th:if="${#lists.isEmpty(recentGrades)}">결과가 없습니다</li>
+        </ul>
+    </div>
 </div>
 
 </body>


### PR DESCRIPTION
## Summary
- add JPQL query for recent grade results
- expose service to retrieve latest results
- show recent result status on testcase page

## Testing
- `./gradlew test -q` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6843f15652388324ac9039aa28b32b22